### PR TITLE
feat: Add news data integration and individual section refresh

### DIFF
--- a/app/components/TickerWorkbenchEarnings.vue
+++ b/app/components/TickerWorkbenchEarnings.vue
@@ -1,5 +1,27 @@
 <template>
   <div class="space-y-6">
+    <!-- Header with Refresh Button -->
+    <div class="flex items-center justify-between mb-4">
+      <h2 class="text-xl font-semibold text-gray-900 dark:text-white">Earnings Calls</h2>
+      <UButton
+        @click="$emit('refresh')"
+        variant="soft"
+        icon="i-heroicons-arrow-path"
+        size="sm"
+        :loading="loading"
+      >
+        Refresh Earnings
+      </UButton>
+    </div>
+
+    <!-- Loading State -->
+    <div v-if="loading" class="text-center py-16">
+      <UIcon name="i-heroicons-arrow-path" class="animate-spin text-4xl text-primary-600 mb-4" />
+      <p class="text-gray-600 dark:text-gray-400">Refreshing earnings data...</p>
+    </div>
+
+    <!-- Earnings Overview -->
+    <div v-else class="space-y-6">
     <!-- Earnings Overview -->
     <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
       <UCard class="text-center">
@@ -215,6 +237,7 @@
         </div>
       </div>
     </UCard>
+    </div>
   </div>
 </template>
 
@@ -222,7 +245,10 @@
 const props = defineProps<{
   ticker: string;
   earnings: any[];
+  loading?: boolean;
 }>();
+
+defineEmits(['refresh']);
 
 // Get latest earnings
 const latestEarnings = computed(() => {

--- a/app/components/TickerWorkbenchFundamentals.vue
+++ b/app/components/TickerWorkbenchFundamentals.vue
@@ -1,26 +1,37 @@
 <template>
   <div class="space-y-8">
-    <!-- Header with Period Selector -->
+    <!-- Header with Period Selector and Refresh Button -->
     <div class="flex items-center justify-between">
       <h2 class="text-2xl font-bold text-gray-900 dark:text-white">
         Fundamental Data
       </h2>
-      <UButtonGroup>
+      <div class="flex items-center space-x-3">
+        <UButtonGroup>
+          <UButton
+            :variant="selectedPeriod === 'yearly' ? 'solid' : 'outline'"
+            @click="selectedPeriod = 'yearly'"
+            size="sm"
+          >
+            Yearly
+          </UButton>
+          <UButton
+            :variant="selectedPeriod === 'quarterly' ? 'solid' : 'outline'"
+            @click="selectedPeriod = 'quarterly'"
+            size="sm"
+          >
+            Quarterly
+          </UButton>
+        </UButtonGroup>
         <UButton
-          :variant="selectedPeriod === 'yearly' ? 'solid' : 'outline'"
-          @click="selectedPeriod = 'yearly'"
+          @click="handleRefresh"
+          variant="soft"
+          icon="i-heroicons-arrow-path"
           size="sm"
+          :loading="loading"
         >
-          Yearly
+          Refresh Data
         </UButton>
-        <UButton
-          :variant="selectedPeriod === 'quarterly' ? 'solid' : 'outline'"
-          @click="selectedPeriod = 'quarterly'"
-          size="sm"
-        >
-          Quarterly
-        </UButton>
-      </UButtonGroup>
+      </div>
     </div>
 
     <!-- Loading State -->
@@ -200,9 +211,15 @@ const props = defineProps<{
   ticker: string;
 }>();
 
+const emit = defineEmits(['refresh']);
+
 const loading = ref(false);
 const fundamentalData = ref<any>(null);
 const selectedPeriod = ref<'yearly' | 'quarterly'>('yearly');
+
+const handleRefresh = () => {
+  emit('refresh');
+};
 
 const hasData = computed(() => {
   return fundamentalData.value && fundamentalData.value.financials;

--- a/app/components/TickerWorkbenchNews.vue
+++ b/app/components/TickerWorkbenchNews.vue
@@ -1,7 +1,27 @@
 <template>
   <div class="space-y-6">
+    <!-- Header with Refresh Button -->
+    <div class="flex items-center justify-between mb-4">
+      <h2 class="text-xl font-semibold text-gray-900 dark:text-white">News Articles</h2>
+      <UButton
+        @click="$emit('refresh')"
+        variant="soft"
+        icon="i-heroicons-arrow-path"
+        size="sm"
+        :loading="loading"
+      >
+        Refresh News
+      </UButton>
+    </div>
+
+    <!-- Loading State -->
+    <div v-if="loading" class="text-center py-16">
+      <UIcon name="i-heroicons-arrow-path" class="animate-spin text-4xl text-primary-600 mb-4" />
+      <p class="text-gray-600 dark:text-gray-400">Refreshing news data...</p>
+    </div>
+
     <!-- News Articles List -->
-    <div v-if="articles.length === 0" class="text-center py-12">
+    <div v-else-if="articles.length === 0" class="text-center py-12">
       <UIcon name="i-heroicons-newspaper" class="text-5xl text-gray-400 mb-3" />
       <p class="text-gray-600 dark:text-gray-400">No news articles found</p>
     </div>
@@ -28,55 +48,55 @@
               <!-- Header -->
               <div class="flex items-start justify-between">
                 <h3 class="font-semibold text-gray-900 dark:text-gray-100 line-clamp-2 flex-1">
-                  {{ article.headline }}
+                  {{ article.title }}
                 </h3>
-                <UBadge 
-                  :color="getSentimentBadgeColor(article.sentiment)"
+                <UBadge
+                  :color="getSentimentBadgeColor(article.sentiment?.polarity || 0.5)"
                   variant="subtle"
                   class="ml-2"
                 >
-                  {{ article.sentiment }}
+                  {{ getSentimentLabel(article.sentiment?.polarity || 0.5) }}
                 </UBadge>
               </div>
 
               <!-- Meta Information -->
               <div class="flex items-center space-x-4 text-sm text-gray-600 dark:text-gray-400">
-                <span class="flex items-center space-x-1">
+                <span v-if="article.symbols && article.symbols.length > 0" class="flex items-center space-x-1">
                   <UIcon name="i-heroicons-building-office-2" class="w-4 h-4" />
-                  <span>{{ article.source }}</span>
+                  <span>{{ article.symbols[0] }}</span>
                 </span>
                 <span class="flex items-center space-x-1">
                   <UIcon name="i-heroicons-clock" class="w-4 h-4" />
-                  <span>{{ article.date }}</span>
+                  <span>{{ formatDate(article.date) }}</span>
                 </span>
               </div>
 
               <!-- Summary -->
               <p class="text-sm text-gray-700 dark:text-gray-300 line-clamp-2">
-                {{ article.summary }}
+                {{ article.content ? article.content.substring(0, 200) + '...' : 'No content available' }}
               </p>
 
               <!-- Actions -->
               <div class="flex items-center justify-between pt-2">
                 <div class="flex items-center space-x-3">
-                  <button 
-                    @click="toggleBookmark(article.id)"
+                  <button
+                    @click="toggleBookmark(article.link)"
                     class="text-gray-500 hover:text-primary-600 transition-colors"
                   >
-                    <UIcon 
-                      :name="isBookmarked(article.id) ? 'i-heroicons-bookmark-solid' : 'i-heroicons-bookmark'"
+                    <UIcon
+                      :name="isBookmarked(article.link) ? 'i-heroicons-bookmark-solid' : 'i-heroicons-bookmark'"
                       class="w-5 h-5"
                     />
                   </button>
-                  <button 
+                  <button
                     @click="shareArticle(article)"
                     class="text-gray-500 hover:text-primary-600 transition-colors"
                   >
                     <UIcon name="i-heroicons-share" class="w-5 h-5" />
                   </button>
                 </div>
-                <a 
-                  :href="article.url"
+                <a
+                  :href="article.link"
                   target="_blank"
                   class="text-primary-600 dark:text-primary-400 hover:underline text-sm flex items-center space-x-1"
                 >
@@ -138,14 +158,17 @@
 const props = defineProps<{
   ticker: string;
   articles: any[];
+  loading?: boolean;
 }>();
+
+defineEmits(['refresh']);
 
 // Pagination
 const currentPage = ref(1);
 const pageSize = 5;
 
 // Bookmarked articles (stored locally)
-const bookmarkedArticles = ref(new Set<number>());
+const bookmarkedArticles = ref(new Set<string>());
 
 const totalPages = computed(() => Math.ceil(props.articles.length / pageSize));
 
@@ -155,21 +178,29 @@ const paginatedArticles = computed(() => {
   return props.articles.slice(start, end);
 });
 
+// Helper function to determine sentiment from polarity value
+const getSentimentLabel = (polarity: number) => {
+  if (polarity >= 0.6) return 'positive';
+  if (polarity <= 0.4) return 'negative';
+  return 'neutral';
+};
+
 // Sentiment counts
-const positiveCount = computed(() => 
-  props.articles.filter(a => a.sentiment === 'positive').length
+const positiveCount = computed(() =>
+  props.articles.filter(a => getSentimentLabel(a.sentiment?.polarity || 0.5) === 'positive').length
 );
 
-const neutralCount = computed(() => 
-  props.articles.filter(a => a.sentiment === 'neutral').length
+const neutralCount = computed(() =>
+  props.articles.filter(a => getSentimentLabel(a.sentiment?.polarity || 0.5) === 'neutral').length
 );
 
-const negativeCount = computed(() => 
-  props.articles.filter(a => a.sentiment === 'negative').length
+const negativeCount = computed(() =>
+  props.articles.filter(a => getSentimentLabel(a.sentiment?.polarity || 0.5) === 'negative').length
 );
 
 // Helper functions
-const getSentimentBadgeColor = (sentiment: string) => {
+const getSentimentBadgeColor = (polarity: number) => {
+  const sentiment = getSentimentLabel(polarity);
   switch (sentiment) {
     case 'positive':
       return 'green';
@@ -181,7 +212,25 @@ const getSentimentBadgeColor = (sentiment: string) => {
   }
 };
 
-const toggleBookmark = (articleId: number) => {
+const formatDate = (dateString: string) => {
+  try {
+    const date = new Date(dateString);
+    const now = new Date();
+    const diffMs = now.getTime() - date.getTime();
+    const diffMins = Math.floor(diffMs / 60000);
+    const diffHours = Math.floor(diffMs / 3600000);
+    const diffDays = Math.floor(diffMs / 86400000);
+
+    if (diffMins < 60) return `${diffMins} minutes ago`;
+    if (diffHours < 24) return `${diffHours} hours ago`;
+    if (diffDays < 7) return `${diffDays} days ago`;
+    return date.toLocaleDateString();
+  } catch {
+    return dateString;
+  }
+};
+
+const toggleBookmark = (articleId: string) => {
   if (bookmarkedArticles.value.has(articleId)) {
     bookmarkedArticles.value.delete(articleId);
   } else {
@@ -189,20 +238,20 @@ const toggleBookmark = (articleId: number) => {
   }
 };
 
-const isBookmarked = (articleId: number) => {
+const isBookmarked = (articleId: string) => {
   return bookmarkedArticles.value.has(articleId);
 };
 
 const shareArticle = (article: any) => {
   if (navigator.share) {
     navigator.share({
-      title: article.headline,
-      text: article.summary,
-      url: article.url
+      title: article.title,
+      text: article.content?.substring(0, 200) + '...',
+      url: article.link
     }).catch(err => console.log('Error sharing:', err));
   } else {
     // Fallback: copy to clipboard
-    navigator.clipboard.writeText(`${article.headline}\n\n${article.summary}\n\n${article.url}`);
+    navigator.clipboard.writeText(`${article.title}\n\n${article.link}`);
     alert('Article link copied to clipboard!');
   }
 };

--- a/app/components/TickerWorkbenchPosts.vue
+++ b/app/components/TickerWorkbenchPosts.vue
@@ -1,7 +1,27 @@
 <template>
   <div class="space-y-6">
+    <!-- Header with Refresh Button -->
+    <div class="flex items-center justify-between mb-4">
+      <h2 class="text-xl font-semibold text-gray-900 dark:text-white">Reddit Posts</h2>
+      <UButton
+        @click="$emit('refresh')"
+        variant="soft"
+        icon="i-heroicons-arrow-path"
+        size="sm"
+        :loading="loading"
+      >
+        Refresh Posts
+      </UButton>
+    </div>
+
+    <!-- Loading State -->
+    <div v-if="loading" class="text-center py-16">
+      <UIcon name="i-heroicons-arrow-path" class="animate-spin text-4xl text-primary-600 mb-4" />
+      <p class="text-gray-600 dark:text-gray-400">Refreshing Reddit posts...</p>
+    </div>
+
     <!-- Posts List -->
-    <div v-if="posts.length === 0" class="text-center py-12">
+    <div v-else-if="posts.length === 0" class="text-center py-12">
       <UIcon name="i-heroicons-document-magnifying-glass" class="text-5xl text-gray-400 mb-3" />
       <p class="text-gray-600 dark:text-gray-400">No Reddit posts found for this ticker</p>
     </div>
@@ -126,7 +146,10 @@ const props = defineProps<{
   posts: any[];
   subreddits: string[];
   ticker: string;
+  loading?: boolean;
 }>();
+
+defineEmits(['refresh']);
 
 const currentPage = ref(1);
 const pageSize = 10;

--- a/server/api/eodhd/newsData.post.ts
+++ b/server/api/eodhd/newsData.post.ts
@@ -1,0 +1,114 @@
+import { createClient } from '@supabase/supabase-js';
+
+export default defineEventHandler(async (event) => {
+    const config = useRuntimeConfig();
+    const body = await readBody(event);
+    const { ticker } = body;
+
+    if (!ticker) {
+        throw createError({
+            statusCode: 400,
+            statusMessage: 'Ticker is required',
+            message: 'Ticker is required'
+        });
+    }
+
+    // Initialize Supabase client
+    const supabase = createClient(
+        config.public.supabaseUrl,
+        config.public.supabasePublishableKey
+    );
+
+    try {
+        const tickerWithExchangeCode = ticker.toUpperCase().concat('.US');
+        const response = await fetch(`https://eodhd.com/api/news?s=${tickerWithExchangeCode}&offset=0&limit=10&api_token=${process.env.EODHD_API_KEY}&fmt=json`);
+
+        if(!response.ok) {
+            throw createError({
+                statusCode: response.status,
+                statusMessage: `Error fetching news data from EODHD`,
+                message: response.statusText
+            });
+        }
+
+        const data = await response.json();
+
+        // Process and structure the news data
+        const newsArticles = Array.isArray(data) ? data.map(article => ({
+            date: article.date || null,
+            title: article.title || null,
+            content: article.content || null,
+            link: article.link || null,
+            symbols: article.symbols || [],
+            tags: article.tags || [],
+            sentiment: {
+                polarity: article.sentiment?.polarity || 0,
+                neg: article.sentiment?.neg || 0,
+                neu: article.sentiment?.neu || 0,
+                pos: article.sentiment?.pos || 0
+            }
+        })) : [];
+
+        // Store or update news data in the database
+        // First, check if a record exists for this ticker
+        const { data: existingRecord, error: fetchError } = await supabase
+            .from('ticker_searches')
+            .select('id')
+            .eq('ticker', ticker.toUpperCase())
+            .order('created_at', { ascending: false })
+            .limit(1)
+            .single();
+
+        if (existingRecord) {
+            // Update existing record with news data
+            const { error: updateError } = await supabase
+                .from('ticker_searches')
+                .update({
+                    news_data: newsArticles,
+                    news_data_updated_at: new Date().toISOString()
+                })
+                .eq('id', existingRecord.id);
+
+            if (updateError) {
+                throw createError({
+                    statusCode: 500,
+                    statusMessage: `Error updating ticker search record`,
+                    message: updateError.message
+                });
+            }
+        } else {
+            // Create new record with news data
+            const { error: insertError } = await supabase
+                .from('ticker_searches')
+                .insert({
+                    ticker: ticker.toUpperCase(),
+                    news_data: newsArticles,
+                    news_data_updated_at: new Date().toISOString(),
+                    data_version: 2 // Using new unified format
+                });
+
+            if (insertError) {
+                throw createError({
+                    statusCode: 500,
+                    statusMessage: `Error inserting ticker search record`,
+                    message: insertError.message
+                });
+            }
+        }
+
+        return {
+            success: true,
+            message: `News data for ${ticker.toUpperCase()} fetched and stored successfully`,
+            ticker: ticker.toUpperCase(),
+            articlesCount: newsArticles.length
+        };
+
+    } catch (error: any) {
+        console.error('Error fetching news data:', error);
+        throw createError({
+            statusCode: 500,
+            statusMessage: `Internal Server Error`,
+            message: error.message || 'Internal Server Error'
+        });
+    }
+});

--- a/supabase/migrations/20250929_add_news_data.sql
+++ b/supabase/migrations/20250929_add_news_data.sql
@@ -1,0 +1,18 @@
+-- Add column for news data from EODHD API
+ALTER TABLE ticker_searches
+ADD COLUMN IF NOT EXISTS news_data JSONB;
+
+-- Add index for better query performance on news data
+CREATE INDEX IF NOT EXISTS idx_ticker_searches_news_data ON ticker_searches USING GIN (news_data);
+
+-- Add timestamp for when news data was last updated
+ALTER TABLE ticker_searches
+ADD COLUMN IF NOT EXISTS news_data_updated_at TIMESTAMPTZ;
+
+-- Add index on news data update timestamp
+CREATE INDEX IF NOT EXISTS idx_ticker_searches_news_updated ON ticker_searches(news_data_updated_at);
+
+-- Add comment explaining the news data structure
+COMMENT ON COLUMN ticker_searches.news_data IS 'Stores news articles from EODHD API including title, content, link, symbols, tags, and sentiment data';
+
+COMMENT ON COLUMN ticker_searches.news_data_updated_at IS 'Timestamp of when the news data was last fetched from the API';


### PR DESCRIPTION
## Summary
This PR adds news data integration with the EODHD API and implements individual refresh buttons for each section of the ticker workbench.

## Changes

### 1. News Data Integration
- **Database Migration**: Added `news_data` JSONB column to `ticker_searches` table with proper indexes
- **API Endpoint**: Created `/server/api/eodhd/newsData.post.ts` to fetch news from EODHD API
- **Component Updates**: Updated `TickerWorkbenchNews.vue` to display real news data with:
  - Title, content, link, and sentiment from API
  - Sentiment calculation from polarity values
  - Relative date formatting
  - Summary statistics (positive/neutral/negative counts)

### 2. Individual Section Refresh
Each section now has its own refresh button with loading states:
- **Reddit Posts**: Refreshes Reddit data for default subreddits
- **News Articles**: Fetches latest news from EODHD API
- **Fundamentals**: Refreshes fundamental data from EODHD API
- **Earnings**: Placeholder implementation (API TBD)

### 3. Loading States
- Each section shows a centered spinner with "Refreshing..." message during data fetch
- Content is hidden during refresh and smoothly appears when data loads
- All sections can be refreshed independently without affecting others

## Test Plan
- [ ] Verify news data is fetched and displayed correctly from EODHD API
- [ ] Test individual refresh buttons on all four sections
- [ ] Confirm loading states appear and disappear correctly
- [ ] Check that refreshed data updates the UI after successful API calls
- [ ] Verify database migration applies cleanly
- [ ] Test with different tickers to ensure news data is ticker-specific

## Technical Notes
- News data structure follows EODHD API format with sentiment analysis
- Refresh handlers follow the same pattern as existing `fundamentalData.post.ts`
- Loading states are managed with separate refs for each section
- Earnings refresh is a placeholder until earnings API endpoint is implemented

🤖 Generated with [Claude Code](https://claude.com/claude-code)